### PR TITLE
Fix value return for &FindPDBfile call

### DIFF
--- a/scripts/hhmakemodel.pl
+++ b/scripts/hhmakemodel.pl
@@ -1158,7 +1158,7 @@ sub ExtractPdbcodeAndChain()
 #	return 1; # no SCOP/DALI/pdb sequence 
     }
 
-    &FindPDBfile($pdbcode, $chain);
+    $pdbfile = &FindPDBfile($pdbcode, $chain);
 
     if ($pdbfile eq "") {
 	if ($v>=2) {print("Warning: no pdb file found for sequence name '$name'\n");} 


### PR DESCRIPTION
The script hangs in instances where it cannot find a pdb file referenced in a .hhr file (as it enters an infinite loop elsewhere in the code). This is because the &FindPDBfile() returns the name of the pdb file if it can find it and the file name should be tested at line 1163. The original scripts fails to capture the return value of &FindPDBfile() so this test does not occur correctly.

I have fixed line 1161 to correctly capture the return value.