### PR TITLE
Dumps actual HMM names when using -blasttab in hhblits_mpi

### DIFF
--- a/src/hhhitlist.cpp
+++ b/src/hhhitlist.cpp
@@ -328,7 +328,7 @@ void HitList::PrintM8File(HMM* q, std::stringstream& outbuffer) {
             }
         }
         sprintf(line, "%s\t%s\t%1.3f\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.2E\t%.1f\n",
-                q->name, hit.file, static_cast<float>(matchCount)/static_cast<float>(hit.L), hit.L, missMatchCount, gapOpenCount,
+                q->name, hit.longname, static_cast<float>(matchCount)/static_cast<float>(hit.L), hit.L, missMatchCount, gapOpenCount,
                 hit.i1, hit.i2, hit.j1, hit.j2, hit.Eval, -hit.score_aass);
         outbuffer << line;
     }

--- a/src/hhhitlist.cpp
+++ b/src/hhhitlist.cpp
@@ -328,7 +328,7 @@ void HitList::PrintM8File(HMM* q, std::stringstream& outbuffer) {
             }
         }
         sprintf(line, "%s\t%s\t%1.3f\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%.2E\t%.1f\n",
-                q->name, hit.longname, static_cast<float>(matchCount)/static_cast<float>(hit.L), hit.L, missMatchCount, gapOpenCount,
+                q->name, hit.name, static_cast<float>(matchCount)/static_cast<float>(hit.L), hit.L, missMatchCount, gapOpenCount,
                 hit.i1, hit.i2, hit.j1, hit.j2, hit.Eval, -hit.score_aass);
         outbuffer << line;
     }


### PR DESCRIPTION
When using hhblits_mpi over a ffindex database, the hits reported with `-blasttab` format are internal ids rather than actual hmm names. 
I think this small change would solve it.

ps. Still unsure if `hit.name` would be safer than `hit.longname`