### PR TITLE
fix r_free() in cif2fasta.py

### DIFF
--- a/scripts/cif2fasta.py
+++ b/scripts/cif2fasta.py
@@ -427,7 +427,7 @@ class CIF2FASTA(object):
             r_free = refine.getValue('ls_R_factor_R_free')
 
             try: 
-                r_free = float(r_free)
+                return float(r_free)
             except ValueError:
                 return False
 


### PR DESCRIPTION
fix a bug: r_free() always returns False (that's why pdb_filter.dat has only N/A in the r_free column)