### PR TITLE
Perl 5.26.1: The use of "defined" on arrays no longer supported

### DIFF
--- a/scripts/hhpred/lib/modeller.pm
+++ b/scripts/hhpred/lib/modeller.pm
@@ -837,7 +837,7 @@ sub ChangeDistanceRestraints {
 		$PDBs[$t][$1]=[$2,$3,$4,$5,$6,$7]; 
 
 		## speed up: save all atoms for a given residue (in a given template); will be needed later to compute the distance between "matching" atoms
-	 	if (not defined(@{$atomsForResidue[$t][$4]})) {
+	 	if (not @{$atomsForResidue[$t][$4]}) {
  		    $atomsForResidue[$t][$4] = [$1];
  		}
  		else {
@@ -1229,12 +1229,12 @@ sub DistanceInTemplate {
     my $e = 0; 
     my $f = 0;
 
-    if (defined @{$atomsForResidue[$templatenr][$tempresidueOne]}) {
+    if (@{$atomsForResidue[$templatenr][$tempresidueOne]}) {
 	foreach my $atom (@{$atomsForResidue[$templatenr][$tempresidueOne]}) {
 	    push(@coordinatesOne, [$PDBs[$templatenr][$atom][0],$PDBs[$templatenr][$atom][1],$PDBs[$templatenr][$atom][3],$PDBs[$templatenr][$atom][4],$PDBs[$templatenr][$atom][5]]);
 	}
     }
-    if (defined @{$atomsForResidue[$templatenr][$tempresidueTwo]}) {
+    if (@{$atomsForResidue[$templatenr][$tempresidueTwo]}) {
 	foreach my $atom (@{$atomsForResidue[$templatenr][$tempresidueTwo]}) {
 	    push(@coordinatesTwo, [$PDBs[$templatenr][$atom][0],$PDBs[$templatenr][$atom][1],$PDBs[$templatenr][$atom][3],$PDBs[$templatenr][$atom][4],$PDBs[$templatenr][$atom][5]]);
 	}


### PR DESCRIPTION
At least in Perl v5.26.1 (default on Ubuntu 18.04), the use of `defined @array` produces fatal error, and so `modeller.pm` can not run. There does not seem to be any instances of this construction in other files.

It seems that use of `default` on arrays [is no longer supported](https://perldoc.perl.org/functions/defined.html#defined-EXPR) and has been [deprecated since Perl 5.6.1 release in early 2000s](https://perldoc.perl.org/perl561delta.html#Summary-of-changes-between-5.6.0-and-5.6.1).

Unless there is any need to support such old systems, I think it's safe to apply this patch.