### PR TITLE
Changed hhprefiler to use different SSW implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/ffindex"]
 	path = lib/ffindex
 	url = https://github.com/soedinglab/ffindex_soedinglab.git
+[submodule "lib/ssw"]
+	path = lib/ssw
+	url = https://github.com/stigvp/Complete-Striped-Smith-Waterman-Library

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/soedinglab/ffindex_soedinglab.git
 [submodule "lib/ssw"]
 	path = lib/ssw
-	url = https://github.com/stigvp/Complete-Striped-Smith-Waterman-Library
+	url = https://github.com/stigvp/Complete-Striped-Smith-Waterman-Library.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.12)
-project(hhsuite CXX)
+project(hhsuite C CXX)
 
 SET(HAVE_SSE2 0 CACHE BOOL "Have SSE2")
 SET(HAVE_AVX2 0 CACHE BOOL "Have AVX2")
@@ -57,6 +57,7 @@ INSTALL(FILES
 
 include_directories(src)
 include_directories(lib/ffindex/src)
+include_directories(lib/ssw/src)
 
 add_subdirectory(lib/ffindex)
 add_subdirectory(src)
@@ -100,3 +101,10 @@ set (CPACK_PACKAGE_VERSION_MINOR "${HHSUITE_VERSION_PATCH}")
 INCLUDE(CPack)
 
 enable_testing()
+
+set(SSW_SOURCE 
+      ${CMAKE_CURRENT_SOURCE_DIR}/lib/ssw/src/ssw.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/lib/ssw/src/ssw.c
+)
+
+add_library(ssw OBJECT ${SSW_SOURCE})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,7 @@ add_executable(hhblits
     $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
     $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
     $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+    $<TARGET_OBJECTS:ssw>
 )
 target_link_libraries (hhblits ffindex)
 
@@ -149,6 +150,7 @@ if (OPENMP_FOUND)
         $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
         $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
         $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+        $<TARGET_OBJECTS:ssw>
     )
     target_link_libraries (hhblits_omp ffindex)
 
@@ -157,6 +159,7 @@ if (OPENMP_FOUND)
         $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
         $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
         $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+        $<TARGET_OBJECTS:ssw>
     )
     target_link_libraries (hhsearch_omp ffindex)
 
@@ -165,6 +168,7 @@ if (OPENMP_FOUND)
         $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
         $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
         $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+        $<TARGET_OBJECTS:ssw>
     )
     target_link_libraries (hhblits_ca3m ffindex)
 
@@ -183,6 +187,7 @@ add_executable(hhmake
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
   $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+  $<TARGET_OBJECTS:ssw>
 )
 target_link_libraries (hhmake ffindex)
 
@@ -191,6 +196,7 @@ add_executable(hhfilter
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
   $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+  $<TARGET_OBJECTS:ssw>
 )
 target_link_libraries (hhfilter ffindex)
 
@@ -199,6 +205,7 @@ add_executable(hhsearch
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
   $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+  $<TARGET_OBJECTS:ssw>
 )
 target_link_libraries (hhsearch ffindex)
 
@@ -207,6 +214,7 @@ add_executable(hhalign
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
   $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+  $<TARGET_OBJECTS:ssw>
 )
 target_link_libraries (hhalign ffindex)
 
@@ -215,6 +223,7 @@ add_executable(hhconsensus
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
   $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
   $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+  $<TARGET_OBJECTS:ssw>
 )
 target_link_libraries (hhconsensus ffindex)
 
@@ -254,6 +263,7 @@ add_executable(cstranslate
         $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
         $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
         $<TARGET_OBJECTS:A3M_COMPRESS_OBJECT>
+        $<TARGET_OBJECTS:ssw>
 )
 target_link_libraries (cstranslate ffindex)
 
@@ -268,6 +278,7 @@ if(MPI_CXX_FOUND)
 	         $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff>
 	         $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
 	         $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
+             $<TARGET_OBJECTS:ssw>
 	       )
     target_link_libraries(hhblits_mpi ffindex mpq)
     target_link_libraries(hhblits_mpi ${MPI_CXX_LIBRARIES})
@@ -285,6 +296,7 @@ if(MPI_CXX_FOUND)
             $<TARGET_OBJECTS:hhviterbialgorithm_and_ss>
             $<TARGET_OBJECTS:hhviterbialgorithm_with_celloff_and_ss>
             $<TARGET_OBJECTS:A3M_COMPRESS_OBJECT>
+            $<TARGET_OBJECTS:ssw>
             )
     target_link_libraries(cstranslate_mpi ffindex mpq)
     target_link_libraries(cstranslate_mpi ${MPI_CXX_LIBRARIES})

--- a/src/hhprefilter.cpp
+++ b/src/hhprefilter.cpp
@@ -6,583 +6,417 @@
  */
 
 #include "hhprefilter.h"
+#include "ssw.h"
 
 namespace hh {
 
-#define SWAP(tmp, arg1, arg2) tmp = arg1; arg1 = arg2; arg2 = tmp;
+namespace {
 
-  Prefilter::Prefilter(const char* cs_library,
-      FFindexDatabase* cs219_database) {
+int ungapped_sse_score(simd_int* query_profile, const int query_length,
+                       const char* db_sequence, const int dbseq_length,
+                       const unsigned char score_offset, simd_int* workspace) {
+  int element_count = (VECSIZE_INT * 4);
+  const int W = (query_length + (element_count - 1)) /
+                element_count;  // width of bands in query and score matrix =
+                                // hochgerundetes LQ/16
 
-    num_dbs = 0;
+  simd_int Smax = simdi_setzero();
+  simd_int Zero = simdi_setzero();
 
-    // Prepare column state lib (context size =1 )
-    FILE* fin = fopen(cs_library, "r");
-    if (!fin)
-      OpenFileError(cs_library, __FILE__, __LINE__, __func__);
+  // All scores in query profile are shifted up by Soffset to obtain pos values.
+  // Load the score offset to all 16 unsigned byte elements of Soffset.
+  simd_int Soffset = simdi8_set(score_offset);
 
-    cs_lib = new cs::ContextLibrary<cs::AA>(fin);
-    fclose(fin);
-
-    cs::TransformToLin(*cs_lib);
-
-    init_prefilter(cs219_database);
+  // Initialize  workspace to zero
+  simd_int* p = workspace;
+  for (int i = 0; i < 2 * W; ++i) {
+    simdi_store(p++, Zero);
   }
 
-  Prefilter::~Prefilter() {
-    free(length);
-    free(first);
+  // Pointers to Score(i-1,j-1) and Score(i,j), resp.
+  simd_int* s_prev = workspace + W;
+  simd_int* s_curr = workspace;
 
-    for (size_t n = 0; n < num_dbs; n++)
-      delete[] dbnames[n];
-    free(dbnames);
+  for (int j = 0; j < dbseq_length; ++j)  // loop over db sequence positions
+  {
+    // Get address of query scores for row j (for residue x_j).
+    simd_int* qji = query_profile + db_sequence[j] * W;
 
-    delete cs_lib;
-  }
+    // Load the next S value - 16 unsigned bytes holding S(b*W+i,j) (b=0,..,15).
+    simd_int S = simdi_load(s_curr + W - 1);
+    S = simdi8_shiftl(S, 1);
 
-  int Prefilter::swStripedByte(unsigned char *querySeq, int queryLength,
-      unsigned char *dbSeq, int dbLength, unsigned short gapOpen,
-      unsigned short gapExtend, simd_int *pvHLoad, simd_int *pvHStore,
-      simd_int *pvE, unsigned short bias) {
-    int i, j;
+    // Swap s_prev and s_curr, smax_prev and smax_curr
+    std::swap(s_prev, s_curr);
 
-    unsigned int cmp;
-    int element_count = (VECSIZE_INT * 4);
+    simd_int* s_curr_it = s_curr;
+    simd_int* s_prev_it = s_prev;
 
-    int iter = (queryLength + (element_count - 1)) / element_count; // width of bands in query and score matrix = hochgerundetes LQ/16
+    for (int i = 0; i < W; ++i) {  // loop over query band positions
+      // Saturated addition and subtraction to score S(i,j)
+      S = simdui8_adds(S,
+                       *(qji++));  // S(i,j) = S(i-1,j-1) + (q(i,x_j) + Soffset)
+      S = simdui8_subs(S, Soffset);  // S(i,j) = max(0, S(i,j) - Soffset)
+      simdi_store(s_curr_it++, S);   // store S to s_curr[i]
+      Smax = simdui8_max(Smax, S);   // Smax(i,j) = max(Smax(i,j), S(i,j))
 
-    simd_int *pv;
-
-    simd_int vE, vF, vH;
-
-    simd_int vMaxScore;
-    simd_int vBias;
-    simd_int vGapOpen;
-    simd_int vGapExtend;
-
-    simd_int vTemp;
-    simd_int vZero;
-
-    simd_int *pvScore;
-
-    simd_int *pvQueryProf = (simd_int*) querySeq;
-
-    /* Load the bias to all elements of a constant */
-    vBias = simdi8_set(bias);
-
-    /* Load gap opening penalty to all elements of a constant */
-    vGapOpen = simdi8_set(gapOpen);
-
-    /* Load gap extension penalty to all elements of a constant */
-    vGapExtend = simdi8_set(gapExtend);
-
-    vMaxScore = simdi_setzero();
-    vZero = simdi_setzero();
-
-    /* Zero out the storage vector */
-    for (i = 0; i < iter; ++i) {
-      simdi_store(pvE + i, vMaxScore);
-      simdi_store(pvHStore + i, vMaxScore);
+      // Load the next S and Smax values
+      S = simdi_load(s_prev_it++);
     }
-
-    for (i = 0; i < dbLength; ++i) {
-      /* fetch first data asap. */
-      pvScore = pvQueryProf + dbSeq[i] * iter;
-
-      /* zero out F. */
-      vF = simdi_setzero();
-
-      /* load the next h value */
-      vH = simdi_load(pvHStore + iter - 1);
-      vH = simdi8_shiftl(vH, 1);
-
-      pv = pvHLoad;
-      pvHLoad = pvHStore;
-      pvHStore = pv;
-
-      for (j = 0; j < iter; ++j) {
-        /* load values of vF and vH from previous row (one unit up) */
-        vE = simdi_load(pvE + j);
-
-        /* add score to vH */
-        vH = simdui8_adds(vH, *(pvScore++));
-        vH = simdui8_subs(vH, vBias);
-
-        /* Update highest score encountered this far */
-        vMaxScore = simdui8_max(vMaxScore, vH);
-
-        /* get max from vH, vE and vF */
-        vH = simdui8_max(vH, vE);
-        vH = simdui8_max(vH, vF);
-
-        /* save vH values */
-        simdi_store(pvHStore + j, vH);
-
-        /* update vE value */
-        vH = simdui8_subs(vH, vGapOpen);
-        vE = simdui8_subs(vE, vGapExtend);
-        vE = simdui8_max(vE, vH);
-
-        /* update vF value */
-        vF = simdui8_subs(vF, vGapExtend);
-        vF = simdui8_max(vF, vH);
-
-        /* save vE values */
-        simdi_store(pvE + j, vE);
-
-        /* load the next h value */
-        vH = simdi_load(pvHLoad + j);
-      }
-
-      /* reset pointers to the start of the saved data */
-      j = 0;
-      vH = simdi_load(pvHStore);
-
-      /*  the computed vF value is for the given column.  since */
-      /*  we are at the end, we need to shift the vF value over */
-      /*  to the next column. */
-      vF = simdi8_shiftl(vF, 1);
-      vTemp = simdui8_subs(vH, vGapOpen);
-      vTemp = simdui8_subs(vF, vTemp);
-      vTemp = simdi8_eq(vTemp, vZero);
-      cmp = simdi8_movemask(vTemp);
-#ifdef AVX2
-      while (cmp != 0xffffffff)
-#else
-      while (cmp != 0xffff)
-#endif
-      {
-        vE = simdi_load(pvE + j);
-
-        vH = simdui8_max(vH, vF);
-
-        /* save vH values */
-        simdi_store(pvHStore + j, vH);
-
-        /*  update vE incase the new vH value would change it */
-        vH = simdui8_subs(vH, vGapOpen);
-        vE = simdui8_max(vE, vH);
-        simdi_store(pvE + j, vE);
-
-        /* update vF value */
-        vF = simdui8_subs(vF, vGapExtend);
-
-        ++j;
-        if (j >= iter) {
-          j = 0;
-          vF = simdi8_shiftl(vF, 1);
-        }
-
-        vH = simdi_load(pvHStore + j);
-
-        vTemp = simdui8_subs(vH, vGapOpen);
-        vTemp = simdui8_subs(vF, vTemp);
-        vTemp = simdi8_eq(vTemp, vZero);
-        cmp = simdi8_movemask(vTemp);
-      }
-    }
-
-    /* find largest score in the vMaxScore vector */
-    int score = simd_hmax((unsigned char *) &vMaxScore, element_count);
-
-    /* return largest score */
-    return score;
   }
 
-  int Prefilter::ungapped_sse_score(const unsigned char* query_profile,
-      const int query_length, const unsigned char* db_sequence,
-      const int dbseq_length, const unsigned char score_offset,
-      simd_int* workspace) {
-    int i; // position in query bands (0,..,W-1)
-    int j; // position in db sequence (0,..,dbseq_length-1)
-    int element_count = (VECSIZE_INT * 4);
-    const int W = (query_length + (element_count - 1)) / element_count; // width of bands in query and score matrix = hochgerundetes LQ/16
+  /* return largest score */
+  return simd_hmax((unsigned char*)&Smax, element_count);
+}
 
-    simd_int *p;
-    simd_int S;              // 16 unsigned bytes holding S(b*W+i,j) (b=0,..,15)
-    simd_int Smax = simdi_setzero();
-    simd_int Soffset; // all scores in query profile are shifted up by Soffset to obtain pos values
-    simd_int *s_prev, *s_curr; // pointers to Score(i-1,j-1) and Score(i,j), resp.
-    simd_int *qji;             // query profile score in row j (for residue x_j)
-    simd_int *s_prev_it, *s_curr_it;
-    simd_int *query_profile_it = (simd_int *) query_profile;
-    simd_int Zero = simdi_setzero();
+}  // namespace
 
-    // Load the score offset to all 16 unsigned byte elements of Soffset
-    Soffset = simdi8_set(score_offset);
-
-    // Initialize  workspace to zero
-    for (i = 0, p = workspace; i < 2 * W; ++i)
-      simdi_store(p++, Zero);
-
-    s_curr = workspace;
-    s_prev = workspace + W;
-
-    for (j = 0; j < dbseq_length; ++j) // loop over db sequence positions
-        {
-
-      // Get address of query scores for row j
-      qji = query_profile_it + db_sequence[j] * W;
-
-      // Load the next S value
-      S = simdi_load(s_curr + W - 1);
-      S = simdi8_shiftl(S, 1);
-
-      // Swap s_prev and s_curr, smax_prev and smax_curr
-      SWAP(p, s_prev, s_curr);
-
-      s_curr_it = s_curr;
-      s_prev_it = s_prev;
-
-      for (i = 0; i < W; ++i) // loop over query band positions
-          {
-        // Saturated addition and subtraction to score S(i,j)
-        S = simdui8_adds(S, *(qji++)); // S(i,j) = S(i-1,j-1) + (q(i,x_j) + Soffset)
-        S = simdui8_subs(S, Soffset);       // S(i,j) = max(0, S(i,j) - Soffset)
-        simdi_store(s_curr_it++, S);       // store S to s_curr[i]
-        Smax = simdui8_max(Smax, S);       // Smax(i,j) = max(Smax(i,j), S(i,j))
-
-        // Load the next S and Smax values
-        S = simdi_load(s_prev_it++);
-      }
-    }
-    int score = simd_hmax((unsigned char *) &Smax, element_count);
-
-    /* return largest score */
-    return score;
-  }
-
-  ///////////////////////////////////////////////////////////////////////////////////////////////////
-// Pull out all names from prefilter db file and copy into dbfiles_new for full HMM-HMM comparison
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-  void Prefilter::init_no_prefiltering(FFindexDatabase* query_database,
-      std::vector<std::pair<int, std::string> >& prefiltered_entries) {
-    ffindex_index_t* db_index = query_database->db_index;
+// Pull out all names from prefilter db file and copy into dbfiles_new for full
+// HMM-HMM comparison
+///////////////////////////////////////////////////////////////////////////////////////////////////
+void Prefilter::init_no_prefiltering(
+    FFindexDatabase* query_database,
+    std::vector<std::pair<int, std::string>>& prefiltered_entries) {
+  ffindex_index_t* db_index = query_database->db_index;
 
-    for (size_t n = 0; n < db_index->n_entries; n++) {
-      ffindex_entry_t* entry = ffindex_get_entry_by_index(db_index, n);
+  for (int n = 0; n < db_index->n_entries; n++) {
+    ffindex_entry_t* entry = ffindex_get_entry_by_index(db_index, n);
 
-      prefiltered_entries.push_back(
-          std::make_pair<int, std::string>(entry->length,
-              std::string(entry->name)));
-    }
-
-    HH_LOG(INFO) << "Searching " << prefiltered_entries.size()
-        << " database HHMs without prefiltering" << std::endl;
+    prefiltered_entries.emplace_back(std::make_pair<int, std::string>(
+        entry->length, std::string(entry->name)));
   }
 
-  void Prefilter::init_selected(FFindexDatabase* cs219_database,
-      std::vector<std::string> templates,
-      std::vector<std::pair<int, std::string> >& prefiltered_entries) {
+  HH_LOG(INFO) << "Searching " << prefiltered_entries.size()
+               << " database HHMs without prefiltering" << std::endl;
+}
 
-    ffindex_index_t* db_index = cs219_database->db_index;
+void Prefilter::init_selected(
+    FFindexDatabase* cs219_database, std::vector<std::string> templates,
+    std::vector<std::pair<int, std::string> >& prefiltered_entries) {
+  ffindex_index_t* db_index = cs219_database->db_index;
 
-    for (size_t n = 0; n < templates.size(); n++) {
-      ffindex_entry_t* entry = ffindex_get_entry_by_name(db_index, const_cast<char *>(templates[n].c_str()));
+  for (const auto& template_it : templates) {
+    ffindex_entry_t* entry = ffindex_get_entry_by_name(
+        db_index, const_cast<char*>(template_it.c_str()));
 
-      prefiltered_entries.push_back(
-          std::make_pair<int, std::string>(entry->length,
-              std::string(entry->name)));
-    }
+    prefiltered_entries.emplace_back(std::make_pair<int, std::string>(
+        entry->length, std::string(entry->name)));
   }
+}
 
 //////////////////////////////////////////////////////////////
 // Reading in column state sequences for prefiltering
 //////////////////////////////////////////////////////////////
-  void Prefilter::init_prefilter(FFindexDatabase* cs219_database) {
-    // Set up variables for prefiltering
-    num_dbs = cs219_database->db_index->n_entries;
-    first = (unsigned char**) mem_align(ALIGN_FLOAT, num_dbs * sizeof(unsigned char*));
-    length = (int*) mem_align(ALIGN_FLOAT, num_dbs * sizeof(int));
-    dbnames = (char**) mem_align(ALIGN_FLOAT, num_dbs * sizeof(char*));
-    for (size_t n = 0; n < num_dbs; n++) {
-      ffindex_entry_t* entry = ffindex_get_entry_by_index(
-          cs219_database->db_index, n);
-      first[n] = (unsigned char*) ffindex_get_data_by_entry(
-          cs219_database->db_data, entry);
-      length[n] = entry->length - 1;
-      dbnames[n] = new char[strlen(entry->name) + 1];
-      strcpy(dbnames[n], entry->name);
-    }
-
-    //check if cs219 format is new binary format
-    checkCSFormat(5);
-
-    HH_LOG(INFO) << "Searching " << num_dbs
-        << " column state sequences." << std::endl;
+void Prefilter::init_prefilter(FFindexDatabase* cs219_database) {
+  // Set up variables for prefiltering
+  for (int n = 0; n < cs219_database->db_index->n_entries; n++) {
+    ffindex_entry_t* entry =
+        ffindex_get_entry_by_index(cs219_database->db_index, n);
+    DBEntry db_entry;
+    db_entry.first = ffindex_get_data_by_entry(cs219_database->db_data, entry);
+    db_entry.length = entry->length - 1;
+    db_entry.name = entry->name;
+    dbs_.push_back(db_entry);
   }
 
-  void Prefilter::checkCSFormat(size_t nr_checks) {
-    for (size_t n = 0; n < std::min(nr_checks, num_dbs); n++) {
-      if (first[n][0] == '>') {
-        nr_checks--;
-      }
-    }
+  // check if cs219 format is new binary format
+  checkCSFormat(5);
 
-    if (nr_checks == 0) {
-      HH_LOG(ERROR) << "In " << __FILE__ << ":" << __LINE__ << ": " << __func__ << ":" << std::endl;
-      HH_LOG(ERROR) << "\tYour cs database is in an old format!" << std::endl;
-      HH_LOG(ERROR) << "\tThis format is no longer supportet!" << std::endl;
-      HH_LOG(ERROR) << "\tCorrespond to the user manual!" << std::endl;
-      exit(1);
+  HH_LOG(INFO) << "Searching " << dbs_.size() << " column state sequences."
+               << std::endl;
+}
+
+void Prefilter::checkCSFormat(size_t nr_checks) {
+  for (int n = 0; n < std::min(nr_checks, dbs_.size()); n++) {
+    if (dbs_[n].first[0] == '>') {
+      nr_checks--;
     }
   }
+
+  if (nr_checks == 0) {
+    HH_LOG(ERROR) << "In " << __FILE__ << ":" << __LINE__ << ": " << __func__
+                  << ":" << std::endl;
+    HH_LOG(ERROR) << "\tYour cs database is in an old format!" << std::endl;
+    HH_LOG(ERROR) << "\tThis format is no longer supportet!" << std::endl;
+    HH_LOG(ERROR) << "\tCorrespond to the user manual!" << std::endl;
+    exit(1);
+  }
+}
 
 ////////////////////////////////////////////////////////////////////////
 // Prepare query profile for prefitering
 ////////////////////////////////////////////////////////////////////////
-  void Prefilter::stripe_query_profile(HMM* q_tmp,
-      const int prefilter_score_offset, const int prefilter_bit_factor,
-      const int W, unsigned char* qc) {
-    int LQ = q_tmp->L;
-    float** query_profile = NULL;
-    int a, h, i, j, k;
+void Prefilter::stripe_query_profile(HMM* q_tmp,
+                                     const int prefilter_score_offset,
+                                     const int prefilter_bit_factor,
+                                     const int W, unsigned char* qc) {
+  // Build query profile with 219 column states
+  int LQ = q_tmp->L;
+  std::vector<float*> query_profile(LQ + 1);
+  for (int i = 0; i < LQ + 1; ++i)
+    query_profile[i] = (float*)malloc_simd_int(NUMCOLSTATES * sizeof(float));
 
-    // Build query profile with 219 column states
-    query_profile = new float*[LQ + 1];
-    for (i = 0; i < LQ + 1; ++i)
-      query_profile[i] = (float*) malloc_simd_int(hh::NUMCOLSTATES * sizeof(float));
+  const cs::ContextLibrary<cs::AA>& lib = *cs_lib_;
 
-    const cs::ContextLibrary<cs::AA>& lib = *cs_lib;
-
-    // log (S(i,k)) = log ( SUM_a p(i,a) * p(k,a) / f(a) )   k: column state, i: pos in ali, a: amino acid
-    for (i = 0; i < LQ; ++i)
-      for (k = 0; k < hh::NUMCOLSTATES; ++k) {
-        float sum = 0;
-        for (a = 0; a < 20; ++a)
-          sum += ((q_tmp->p[i][a] * lib[k].probs[0][a]) / q_tmp->pav[a]);
-        query_profile[i + 1][k] = sum;
-
-      }
-
-    /////////////////////////////////////////
-    // Stripe query profile with chars
-    int element_count = (VECSIZE_INT * 4);
-
-    for (a = 0; a < hh::NUMCOLSTATES; ++a) {
-      h = a * W * element_count;
-      for (i = 0; i < W; ++i) {
-        j = i;
-        for (k = 0; k < element_count; ++k) {
-          if (j >= LQ)
-            qc[h] = (unsigned char) prefilter_score_offset;
-          else {
-            float dummy = flog2(query_profile[j + 1][a])
-                * prefilter_bit_factor + prefilter_score_offset + 0.5;
-            if (dummy > 255.0)
-              qc[h] = 255;
-            else if (dummy < 0)
-              qc[h] = 0;
-            else
-              qc[h] = (unsigned char) dummy; // 1/3 bits & make scores >=0 everywhere
-          }
-          ++h;
-          j += W;
-        }
-      }
+  // log (S(i,k)) = log ( SUM_a p(i,a) * p(k,a) / f(a) )   k: column state, i:
+  // pos in ali, a: amino acid
+  for (int i = 0; i < LQ; ++i)
+    for (int k = 0; k < NUMCOLSTATES; ++k) {
+      float sum = 0;
+      for (int a = 0; a < 20; ++a)
+        sum += ((q_tmp->p[i][a] * lib[k].probs[0][a]) / q_tmp->pav[a]);
+      query_profile[i + 1][k] = sum;
     }
 
-    // Add extra ANY-state (220'th state)
-    h = hh::NUMCOLSTATES * W * element_count;
-    for (i = 0; i < W; ++i) {
-      j = i;
-      for (k = 0; k < element_count; ++k) {
+  /////////////////////////////////////////
+  // Stripe query profile with chars
+  int element_count = (VECSIZE_INT * 4);
+
+  for (int a = 0; a < NUMCOLSTATES; ++a) {
+    int h = a * W * element_count;
+    for (int i = 0; i < W; ++i) {
+      int j = i;
+      for (int k = 0; k < element_count; ++k) {
         if (j >= LQ)
-          qc[h] = (unsigned char) prefilter_score_offset;
-        else
-          qc[h] = (unsigned char) (prefilter_score_offset - 1);
-        h++;
+          qc[h] = static_cast<unsigned char>(prefilter_score_offset);
+        else {
+          float dummy = flog2(query_profile[j + 1][a]) * prefilter_bit_factor +
+                        prefilter_score_offset + 0.5;
+          if (dummy > 255.0) {
+            qc[h] = 255;
+          } else if (dummy < 0) {
+            qc[h] = 0;
+          } else {
+            // 1/3 bits & make scores >=0 everywhere
+            qc[h] = static_cast<unsigned char>(dummy);
+          }
+        }
+        ++h;
         j += W;
       }
     }
-
-    for (i = 0; i < LQ + 1; ++i)
-      free(query_profile[i]);
-    delete[] query_profile;
   }
 
+  // Add extra ANY-state (220'th state)
+  int h = NUMCOLSTATES * W * element_count;
+  for (int i = 0; i < W; ++i) {
+    int j = i;
+    for (int k = 0; k < element_count; ++k) {
+      if (j >= LQ)
+        qc[h] = static_cast<unsigned char>(prefilter_score_offset);
+      else
+        qc[h] = static_cast<unsigned char>(prefilter_score_offset - 1);
+      h++;
+      j += W;
+    }
+  }
+
+  for (int i = 0; i < LQ + 1; ++i) {
+    free(query_profile[i]);
+  }
+}
+
+Prefilter::Prefilter(const char* cs_library, FFindexDatabase* cs219_database) {
+  // Prepare column state lib (context size =1 )
+  FILE* fin = fopen(cs_library, "r");
+  if (!fin) OpenFileError(cs_library, __FILE__, __LINE__, __func__);
+
+  cs_lib_ = std::make_unique<cs::ContextLibrary<cs::AA>>(fin);
+  fclose(fin);
+
+  cs::TransformToLin(*cs_lib_);
+
+  init_prefilter(cs219_database);
+}
 
 ////////////////////////////////////////////////////////////////////////
 // Main prefilter function
 ////////////////////////////////////////////////////////////////////////
-  void Prefilter::prefilter_db(HMM* q_tmp, Hash<Hit>* previous_hits,
-      const int threads, const int prefilter_gap_open,
-      const int prefilter_gap_extend, const int prefilter_score_offset,
-      const int prefilter_bit_factor, const double prefilter_evalue_thresh,
-      const double prefilter_evalue_coarse_thresh,
-      const int preprefilter_smax_thresh, const int min_prefilter_hits, const int maxnumdb,
-      const float R[20][20],
-      std::vector<std::pair<int, std::string> >& new_prefilter_hits,
-      std::vector<std::pair<int, std::string> >& old_prefilter_hits) {
+void Prefilter::prefilter_db(
+    HMM* q_tmp, Hash<Hit>* previous_hits, const int threads,
+    const int prefilter_gap_open, const int prefilter_gap_extend,
+    const int prefilter_score_offset, const int prefilter_bit_factor,
+    const double prefilter_evalue_thresh,
+    const double prefilter_evalue_coarse_thresh,
+    const int preprefilter_smax_thresh, const int min_prefilter_hits,
+    const int maxnumdb, const float R[20][20],
+    std::vector<std::pair<int, std::string>>& new_prefilter_hits,
+    std::vector<std::pair<int, std::string>>& old_prefilter_hits) {
+  std::unique_ptr<Hash<char>> doubled = std::make_unique<Hash<char>>();
+  doubled->New(16381, 0);
 
-    Hash<char>* doubled = new Hash<char>;
-    doubled->New(16381, 0);
+  int element_count = (VECSIZE_INT * 4);
+  int W = (q_tmp->L + (element_count - 1)) / element_count;
+  // query profile (states + 1 because of ANY char)
+  int profile_element_count = (NUMCOLSTATES + 1) * (q_tmp->L + element_count);
+  simd_int* qc = malloc_simd_int(profile_element_count * sizeof(unsigned char));
+  stripe_query_profile(q_tmp, prefilter_score_offset, prefilter_bit_factor, W,
+                       reinterpret_cast<unsigned char*>(qc));
 
-    int element_count = (VECSIZE_INT * 4);
-    //W = (LQ+15) / 16;   // band width = hochgerundetes LQ/16
-    int W = (q_tmp->L + (element_count - 1)) / element_count;
-    // query profile (states + 1 because of ANY char)
-    unsigned char* qc = (unsigned char*)malloc_simd_int((hh::NUMCOLSTATES+1)*(q_tmp->L+element_count)*sizeof(unsigned char));
-    stripe_query_profile(q_tmp, prefilter_score_offset, prefilter_bit_factor, W, qc);
+  std::vector<simd_int*> workspaces(threads);
 
-    simd_int ** workspace = new simd_int *[threads];
+  std::vector<std::pair<int, int>> first_prefilter;
+  std::vector<std::pair<double, int>> hits;
 
-    std::vector<std::pair<int, int> > first_prefilter;
-    std::vector<std::pair<double, int> > hits;
+  int count_dbs = 0;
+  int gap_init = prefilter_gap_open + prefilter_gap_extend;
+  int gap_extend = prefilter_gap_extend;
+  int LQ = q_tmp->L;
+  const float log_qlen = flog2(LQ);
+  const double factor = static_cast<double>(dbs_.size() * LQ);
 
-    int count_dbs = 0;
-    int gap_init = prefilter_gap_open + prefilter_gap_extend;
-    int gap_extend = prefilter_gap_extend;
-    int LQ = q_tmp->L;
-    const float log_qlen = flog2(LQ);
-    const double factor = (double) num_dbs * LQ;
+  s_profile* ssw_profile =
+      ssw_hhblits_init(reinterpret_cast<__m128i*>(qc), LQ, NUMCOLSTATES + 1, prefilter_score_offset);
 
-    for (int i = 0; i < threads; i++)
-      workspace[i] = (simd_int*) malloc_simd_int(
-          3 * (LQ + element_count) * sizeof(char));
-
-#pragma omp parallel for schedule(static)
-    // Loop over all database sequences
-    for (size_t n = 0; n < num_dbs; n++) {
-      int thread_id = 0;
-#ifdef OPENMP
-      thread_id = omp_get_thread_num();
-#endif
-      // Perform search step
-      int score = ungapped_sse_score(qc, LQ, first[n], length[n],
-          prefilter_score_offset, workspace[thread_id]);
-
-      score = score
-          - (int) (prefilter_bit_factor * (log_qlen + flog2(length[n])));
-
-#pragma omp critical
-      first_prefilter.push_back(std::pair<int, int>(score, n));
-    }
-    //filter after calculation of ungapped sse score to include at least min_prefilter_hits
-    std::vector<std::pair<int, int> >::iterator it;
-
-    sort(first_prefilter.begin(), first_prefilter.end());
-    std::reverse(first_prefilter.begin(), first_prefilter.end());
-
-    std::vector<std::pair<int, int> >::iterator first_prefilter_begin_erase =
-        first_prefilter.end();
-    std::vector<std::pair<int, int> >::iterator first_prefilter_end_erase =
-        first_prefilter.end();
-    count_dbs = 0;
-    for (it = first_prefilter.begin(); it < first_prefilter.end(); it++) {
-      if (count_dbs >= min_prefilter_hits
-          && (*it).first <= preprefilter_smax_thresh) {
-        first_prefilter_begin_erase = it;
-        break;
-      }
-      else {
-        count_dbs++;
-      }
-    }
-
-    first_prefilter.erase(first_prefilter_begin_erase,
-        first_prefilter_end_erase);
-
-    HH_LOG(INFO)
-        << "HMMs passed 1st prefilter (gapless profile-profile alignment)  : "
-        << count_dbs << std::endl;
-
-#pragma omp parallel for schedule(static)
-    // Loop over all database sequences
-//  for (int n = 0; n < count_dbs; n++) {
-    for (size_t i = 0; i < first_prefilter.size(); i++) {
-      int thread_id = 0;
-#ifdef OPENMP
-      thread_id = omp_get_thread_num();
-#endif
-
-      int n = first_prefilter[i].second;
-
-      // Perform search step
-      int score = swStripedByte(qc, LQ, first[n], length[n], gap_init,
-          gap_extend, workspace[thread_id], workspace[thread_id] + W,
-          workspace[thread_id] + 2 * W, prefilter_score_offset);
-
-      double evalue = factor * length[n] * fpow2(-score / prefilter_bit_factor);
-
-      if (evalue < prefilter_evalue_coarse_thresh) {
-#pragma omp critical
-        hits.push_back(std::pair<double, int>(evalue, n));
-      }
-    }
-
-    //filter after calculation of evalues to include at least min_prefilter_hits
-    sort(hits.begin(), hits.end());
-
-    std::vector<std::pair<double, int> >::iterator second_prefilter_begin_erase =
-        hits.end();
-    std::vector<std::pair<double, int> >::iterator second_prefilter_end_erase =
-        hits.end();
-    std::vector<std::pair<double, int> >::iterator it2;
-
-    count_dbs = 0;
-    for (it2 = hits.begin(); it2 < hits.end(); it2++) {
-      if (count_dbs >= min_prefilter_hits
-          && (*it2).first > prefilter_evalue_thresh) {
-        second_prefilter_begin_erase = it2;
-        break;
-      }
-      else {
-        count_dbs++;
-      }
-    }
-
-    hits.erase(second_prefilter_begin_erase, second_prefilter_end_erase);
-
-    count_dbs = 0;
-
-    for (it2 = hits.begin(); it2 < hits.end(); it2++) {
-      // Add hit to dbfiles
-      count_dbs++;
-      char db_name[NAMELEN];
-      strcpy(db_name, dbnames[(*it2).second]);
-
-      char name[NAMELEN];
-      RemoveExtension(name, db_name);
-
-      if (!doubled->Contains(db_name)) {
-        doubled->Add(db_name);
-
-        std::pair<int, std::string> result;
-        result.first = length[(*it2).second];
-        result.second = std::string(db_name);
-
-        // check, if DB was searched in previous rounds
-
-        std::stringstream ss_tmp;
-        ss_tmp << name << "__" << 1;
-
-        if (previous_hits->Contains((char*) ss_tmp.str().c_str())) {
-          old_prefilter_hits.push_back(result);
-        }
-        else {
-          new_prefilter_hits.push_back(result);
-        }
-      }
-      if (count_dbs >= maxnumdb)
-      {
-        HH_LOG(WARNING)
-        << "Number of hits passing 2nd prefilter (reduced from " << hits.size() << " to allowed maximum of " << maxnumdb << ").\n"
-        <<"You can increase the allowed maximum using the -maxfilt <max> option.\n";
-        break;
-      }
-    }
-
-
-      
-      
-    // Free memory
-    free(qc);
-    for (int i = 0; i < threads; i++)
-      free(workspace[i]);
-    delete[] workspace;
-    if (doubled)
-      delete doubled;
+  for (auto& workspace : workspaces) {
+    workspace =
+        (simd_int*)malloc_simd_int(3 * (LQ + element_count) * sizeof(char));
   }
 
+#pragma omp parallel for schedule(static)
+  // Loop over all database sequences
+  for (size_t n = 0; n < dbs_.size(); n++) {
+    const auto& db_entry = dbs_[n];
+    int thread_id = 0;
+#ifdef OPENMP
+    thread_id = omp_get_thread_num();
+#endif
+    // Perform search step
+    int score =
+        ungapped_sse_score(qc, LQ, db_entry.first, db_entry.length,
+                           prefilter_score_offset, workspaces[thread_id]);
+
+    score = score -
+            (int)(prefilter_bit_factor * (log_qlen + flog2(db_entry.length)));
+
+#pragma omp critical
+    first_prefilter.push_back(std::pair<int, int>(score, n));
+  }
+  // filter after calculation of ungapped sse score to include at least
+  // min_prefilter_hits
+  std::vector<std::pair<int, int>>::iterator it;
+
+  sort(first_prefilter.begin(), first_prefilter.end());
+  std::reverse(first_prefilter.begin(), first_prefilter.end());
+
+  std::vector<std::pair<int, int>>::iterator first_prefilter_begin_erase =
+      first_prefilter.end();
+  std::vector<std::pair<int, int>>::iterator first_prefilter_end_erase =
+      first_prefilter.end();
+  count_dbs = 0;
+  for (it = first_prefilter.begin(); it < first_prefilter.end(); it++) {
+    if (count_dbs >= min_prefilter_hits &&
+        (*it).first <= preprefilter_smax_thresh) {
+      first_prefilter_begin_erase = it;
+      break;
+    } else {
+      count_dbs++;
+    }
+  }
+
+  first_prefilter.erase(first_prefilter_begin_erase, first_prefilter_end_erase);
+
+  HH_LOG(INFO)
+      << "HMMs passed 1st prefilter (gapless profile-profile alignment)  : "
+      << count_dbs << std::endl;
+
+#pragma omp parallel for schedule(static)
+  // Loop over all database sequences
+  for (size_t i = 0; i < first_prefilter.size(); i++) {
+    // int thread_id = 0;
+#ifdef OPENMP
+    // thread_id = omp_get_thread_num();
+#endif
+
+    int n = first_prefilter[i].second;
+    const auto& db_entry = dbs_[n];
+
+    s_align* align_result =
+        ssw_align(ssw_profile, reinterpret_cast<const uint8_t*>(db_entry.first),
+                  db_entry.length, gap_init, gap_extend, 0, 0, 0, 15);
+
+    if (align_result == nullptr) {
+      HH_LOG(ERROR) << "SSW algorithm failed.";
+      continue;
+    }
+    int score = align_result->score1;
+    align_destroy(align_result);
+
+    double evalue =
+        factor * db_entry.length * fpow2(-score / prefilter_bit_factor);
+
+    if (evalue < prefilter_evalue_coarse_thresh) {
+#pragma omp critical
+      hits.push_back(std::pair<double, int>(evalue, n));
+    }
+  }
+
+  // filter after calculation of evalues to include at least
+  // min_prefilter_hits
+  sort(hits.begin(), hits.end());
+
+  std::vector<std::pair<double, int>>::iterator second_prefilter_begin_erase =
+      hits.end();
+  std::vector<std::pair<double, int>>::iterator second_prefilter_end_erase =
+      hits.end();
+  std::vector<std::pair<double, int>>::iterator it2;
+
+  count_dbs = 0;
+  for (it2 = hits.begin(); it2 < hits.end(); it2++) {
+    if (count_dbs >= min_prefilter_hits &&
+        (*it2).first > prefilter_evalue_thresh) {
+      second_prefilter_begin_erase = it2;
+      break;
+    } else {
+      count_dbs++;
+    }
+  }
+
+  hits.erase(second_prefilter_begin_erase, second_prefilter_end_erase);
+
+  count_dbs = 0;
+
+  for (it2 = hits.begin(); it2 < hits.end(); it2++) {
+    // Add hit to dbfiles
+    count_dbs++;
+    const auto& db_name = dbs_[(*it2).second].name;
+
+    char name[NAMELEN];
+    RemoveExtension(name, (char*)db_name.c_str());
+
+    if (!doubled->Contains(db_name.c_str())) {
+      doubled->Add((char*)db_name.c_str());
+
+      std::pair<int, std::string> result;
+      result.first = dbs_[(*it2).second].length;
+      result.second = db_name;
+
+      // check, if DB was searched in previous rounds
+      std::stringstream ss_tmp;
+      ss_tmp << name << "__" << 1;
+
+      if (previous_hits->Contains((char*)ss_tmp.str().c_str())) {
+        old_prefilter_hits.push_back(result);
+      } else {
+        new_prefilter_hits.push_back(result);
+      }
+    }
+    if (count_dbs >= maxnumdb) {
+      HH_LOG(WARNING) << "Number of hits passing 2nd prefilter (reduced from "
+                      << hits.size() << " to allowed maximum of " << maxnumdb
+                      << ").\n"
+                      << "You can increase the allowed maximum using the "
+                         "-maxfilt <max> option.\n";
+      break;
+    }
+  }
+
+  // Free memory
+  free(qc);
+  for (auto& workspace : workspaces) {
+    free(workspace);
+  }
+  init_destroy(ssw_profile);
+}
 } /* namespace hh */

--- a/src/hhprefilter.h
+++ b/src/hhprefilter.h
@@ -8,113 +8,90 @@
 #ifndef HHPREFILTER_H_
 #define HHPREFILTER_H_
 
-#include <vector>
-#ifdef OPENMP
-#include <omp.h>
-#endif
 namespace hh {
 class Prefilter;
 }
 
-#include "hhhmm.h"
+
+#ifdef OPENMP
+#include <omp.h>
+#endif
+
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "hash.h"
 #include "hhhit.h"
-#include "hhdatabase.h"
-#include "simd.h"
-#include "sstream"
+#include "hhhmm.h"
 
 namespace hh {
 
-const int SHORT_BIAS = 32768;
-const int NUMCOLSTATES = cs::AS219::kSize;
+struct DBEntry {
+  // Sequence names in prefilter db file.
+  std::string name;
 
-//////////////////////////////////////////////////////////////////////////////////////////
-//     This file contains code adapted from Michael Farrar
-//     (http://sites.google.com/site/farrarmichael/smith-waterman). His code is marked.
-//     The copy right of his code is shown below:
+  // Pointer to first letter of next sequence in db_data.
+  char* first;
 
-//     Copyright 2006, by Michael Farrar.  All rights reserved. The SWSSE2
-//     program and documentation may not be sold or incorporated into a
-//     commercial product, in whole or in part, without written consent of
-//     Michael Farrar.
-//
-//     For further information regarding permission for use or reproduction,
-//     please contact Michael Farrar at:
-//
-//         farrar.michael@gmail.com
-//
-//
-//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-//     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-//     MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//     IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-//     CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-//     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  // Length of next sequence.
+  int length;
+};
 
-//     Reference:
-//     Farrar M. Striped Smith-Waterman speeds database searches
-//     six times over other SIMD implementations. Bioinformatics. 2007, 23:156-61.
-//
-//     Michael Farrar died unexpectedly in December 2010.
-//     Many thanks posthumously for your great code!
-//     Johannes
-
+// HHSuite Prefilter, applying the Smith-Waterman algorithm to a
+// protein sequence database. 
 
 class Prefilter {
+ public:
+  // Initialize the Prefilter. This initializer will open a file handle and read
+  // the data from disk, and perform some pre-initialization work. Initializing
+  // an instance of this class should be considered an I/O-blocking non-trivial
+  // operation.
+  //
+  // cs_library: The file location of the ContextLibrary that should be used.
+  // cs219_database: The FFindexDatabase to filter.
+  Prefilter(const char* cs_library, FFindexDatabase* cs219_database);
 
-public:
-	Prefilter(const char* cs_library, FFindexDatabase* cs219_database);
-	virtual ~Prefilter();
+  // Reads the FFindexDatabase entries, populating their length and names into
+  // `prefiltered_entries`. `prefiltered_entries` will be populated with pairs
+  // of `<entry length>`, `<entry name>`.
+  static void init_no_prefiltering(
+      FFindexDatabase* cs219_database,
+      std::vector<std::pair<int, std::string>>& prefiltered_entries);
 
-	static void init_no_prefiltering(FFindexDatabase* cs219_database, std::vector<std::pair<int, std::string> >& prefiltered_entries);
-	static void init_selected(FFindexDatabase* cs219_database, std::vector<std::string> templates, std::vector<std::pair<int, std::string> >& prefiltered_entries);
+  // Reads the FFindexDatabase entries from `cs219_database` corresponding to
+  // the entry names in `templates`, populating their length and names into
+  // `prefiltered_entries`. `prefiltered_entries` will be populated with pairs
+  // of `<entry length>`, `<entry name>`.
+  static void init_selected(
+      FFindexDatabase* cs219_database, std::vector<std::string> templates,
+      std::vector<std::pair<int, std::string>>& prefiltered_entries);
 
-	void prefilter_db(HMM* q_tmp, Hash<Hit>* previous_hits,
-			const int threads, const int prefilter_gap_open, const int prefilter_gap_extend,
-			const int prefilter_score_offset, const int prefilter_bit_factor, const double prefilter_evalue_thresh,
-			const double prefilter_evalue_coarse_thresh, const int preprefilter_smax_thresh,
-            const int min_prefilter_hits, const int maxnumdb, const float R[20][20],
-			std::vector<std::pair<int, std::string> >& new_prefilter_hits, std::vector<std::pair<int, std::string> >& old_prefilter_hits);
+  // Pre-filter the database.
+  void prefilter_db(
+      HMM* q_tmp, Hash<Hit>* previous_hits, const int threads,
+      const int prefilter_gap_open, const int prefilter_gap_extend,
+      const int prefilter_score_offset, const int prefilter_bit_factor,
+      const double prefilter_evalue_thresh,
+      const double prefilter_evalue_coarse_thresh,
+      const int preprefilter_smax_thresh, const int min_prefilter_hits,
+      const int maxnumdb, const float R[20][20],
+      std::vector<std::pair<int, std::string>>& new_prefilter_hits,
+      std::vector<std::pair<int, std::string>>& old_prefilter_hits);
 
-private:
-	cs::ContextLibrary<cs::AA> *cs_lib;
+ private:
+  // array containing all sequence names in prefilter db file.
+  std::vector<DBEntry> dbs_;
 
-	// number of sequences in prefilter database file
-	size_t num_dbs;
+  void stripe_query_profile(HMM* q_tmp, const int prefilter_score_offset,
+                            const int prefilter_bit_factor, const int W,
+                            unsigned char* qc);
+  std::unique_ptr<cs::ContextLibrary<cs::AA>> cs_lib_;
 
-	// array containing all sequence names in prefilter db file
-	char** dbnames;
+  void init_prefilter(FFindexDatabase* cs219_database);
+  void checkCSFormat(size_t nr_checks);
 
-	// pointer to first letter of next sequence in db_data
-	unsigned char** first;
-
-	// length of next sequence
-	int* length;
-
-	// extended column state query profile as char
-//	unsigned char* qc;
-//	int W;
-
-	void init_prefilter(FFindexDatabase* cs219_database);
-
-	int ungapped_sse_score(const unsigned char* query_profile,
-		const int query_length, const unsigned char* db_sequence,
-		const int dbseq_length, const unsigned char score_offset, simd_int* workspace);
-
-	int swStripedByte(unsigned char *querySeq,
-		int queryLength,
-		unsigned char *dbSeq,
-		int dbLength,
-		unsigned short gapOpen,
-		unsigned short gapExtend,
-		simd_int *pvHLoad,
-		simd_int *pvHStore,
-		simd_int *pvE,
-		unsigned short bias);
-
-	void checkCSFormat(size_t nr_checks);
-	void stripe_query_profile(HMM* q_tmp, const int prefilter_score_offset, const int prefilter_bit_factor, const int W, unsigned char* qc);
+  const int NUMCOLSTATES = cs::AS219::kSize;
 };
 
 } /* namespace hh */


### PR DESCRIPTION
* Use mengyao/Complete-Striped-Smith-Waterman-Library implementation instead.
* Add this as a git sub module.

Mengyao's SSW implementation required some changes to make it compatible with HHBlits. I have made these in a fork. So hh-suite will depend on this until that gets integrated into the main one (I have a pending pull request).

Tested with a few different runs of HHBlits. Note that ordering of results is different from previous implementation (but looks correct to me).

Could do with testing across different platforms and further verification of the output.