### PR TITLE
Fix handling of CLI arguments in a3m utils

### DIFF
--- a/src/a3m_database_filter.cpp
+++ b/src/a3m_database_filter.cpp
@@ -21,7 +21,8 @@ void usage() {
 }
 
 int main(int argc, char **argv) {
-  bool iflag, sflag, oflag = false;
+  bool iflag, sflag, oflag;
+  iflag = sflag = oflag = false;
 
   std::string set_file;
   std::string ffindex_oa3m_db_prefix;

--- a/src/a3m_database_filter.cpp
+++ b/src/a3m_database_filter.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
         set_file = optarg;
         break;
       case 'o':
-        oflag = optarg;
+        oflag = 1;
         ffindex_oa3m_db_prefix = optarg;
         break;
       case 'h':

--- a/src/a3m_database_reduce.cpp
+++ b/src/a3m_database_reduce.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
         ffindex_sequence_db_prefix = optarg;
         break;
       case 'o':
-        oflag = optarg;
+        oflag = 1;
         ffindex_ca3m_db_prefix = optarg;
         break;
       case 'h':

--- a/src/a3m_database_reduce.cpp
+++ b/src/a3m_database_reduce.cpp
@@ -17,7 +17,8 @@ void usage() {
 }
 
 int main(int argc, char **argv) {
-  bool iflag, dflag, oflag = false;
+  bool iflag, dflag, oflag;
+  iflag = dflag = oflag = false;
 
   std::string ffindex_sequence_db_prefix;
   std::string ffindex_ca3m_db_prefix;

--- a/src/a3m_extract.cpp
+++ b/src/a3m_extract.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
         ffindex_header_db_prefix = optarg;
         break;
       case 'o':
-        oflag = optarg;
+        oflag = 1;
         output = optarg;
         break;
       case 'h':

--- a/src/a3m_reduce.cpp
+++ b/src/a3m_reduce.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
         ffindex_sequence_db_prefix = optarg;
         break;
       case 'o':
-        oflag = optarg;
+        oflag = 1;
         output = optarg;
         break;
       case 'h':

--- a/src/a3m_reduce.cpp
+++ b/src/a3m_reduce.cpp
@@ -9,7 +9,8 @@ void usage() {
 }
 
 int main(int argc, char **argv) {
-  bool iflag, dflag, oflag = false;
+  bool iflag, dflag, oflag;
+  iflag = dflag = oflag = false;
 
   std::string ffindex_sequence_db_prefix;
   std::string output;


### PR DESCRIPTION
Hi!

It seems there are several minor issues when handling argument parsing for a3m_* utilities.

- The flags checking that the specific command line argument was passed are not properly initialized. While unlikely to cause anything (unless you happen to have files named `.ffdata` and `.ffindex`), this produce some inconsistency in output:

```
$ a3m_reduce -o /tmp/reduced_db  # Current behavior. No clear indication that required parameter is missing. 
ERROR: Could not open ffindex sequence data file! (.ffdata)!
$ a3m_reduce -o /tmp/reduced_db # Expected behavior
USAGE: a3m_reduce -i [inputfile|stdin] -o [outputfile|stdout] -d [ffindex_sequence_database_prefix]
```

- The value of `optarg` is assigned to a boolean variable. As far as I can tell, `optarg` is guaranteed to be non-NULL since the argument is marked are required in `getopt` string, so the boolean is set to true anyway, but I think this is a very convoluted way to do it.