### PR TITLE
fixed a bug for global alignment

### DIFF
--- a/src/hhviterbialgorithm.cpp
+++ b/src/hhviterbialgorithm.cpp
@@ -474,7 +474,7 @@ void Viterbi::AlignWithOutCellOff(HMMSimd* q, HMMSimd* t,ViterbiMatrix * viterbi
             //  MAX MAX MAX 0
 
             
-            simd_int curr_pos_j   = simdi32_set(j);
+            simd_int curr_pos_j   = simdi32_set(j-1);
             simd_int new_j_pos_hi = simdi_and(lookup_mask_hi,curr_pos_j);
             simd_int old_j_pos_lo = simdi_and(lookup_mask_lo,j2_vec);
             j2_vec = simdi32_add(new_j_pos_hi,old_j_pos_lo);


### PR DESCRIPTION
I fixed the bug which I raised https://github.com/soedinglab/hh-suite/issues/136
The bug was related to finding the maximum score value. It is happening when I was using a "-glob" option for a global alignment search. The variable "j" becomes t->L+1 after a for-loop (j=1; j<=t->L; ++j), and t->L+1 is used for the "j" value afterward. So, when I was using hhalign, score_vec had exactly the same size of t->L. Yes, it was accessing to a garbage value. 
It affected on "hhalign" (for sure) and the other programs such as hhsearch and hhblits (probably). It may not cause a severe problem for hhsearch/hhblits because they define bigger arrays which are initialized with -inf.