### PR TITLE
A fix for HHfilter

### DIFF
--- a/src/hhalignment.cpp
+++ b/src/hhalignment.cpp
@@ -1916,7 +1916,7 @@ int Alignment::Filter2(char keep[], int coverage, int qid, float qsc,
         }
 
         //dissimilarity < acceptace threshold? Reject!
-        if (diff < diff_suff && float(diff) <= diff_min_frac * cov_kj)
+        if (diff < diff_suff && float(diff) < diff_min_frac * cov_kj)
           break;
       }
 


### PR DESCRIPTION
There was a bug when there was no overlap between two sequences such as
```
>seq_0
AAAA----AAAA
>seq_1
----BBBB----
```
In this case, cov_kj=0 and diff=0, but diff_suff is non-zero. So, in this case, seq_1 is filtered out although there is no overlap between them.

The fix also can be 
`if (diff < diff_suff && float(diff) <= diff_min_frac * cov_kj && cov_kj > 0)`