### PR TITLE
hhviterbialgorithm.cpp - fix ss_score_vec indexing

### DIFF
--- a/src/hhviterbialgorithm.cpp
+++ b/src/hhviterbialgorithm.cpp
@@ -205,9 +205,9 @@ void Viterbi::AlignWithOutCellOff(HMMSimd* q, HMMSimd* t,ViterbiMatrix * viterbi
                 score = &S37[ (int)q_s->ss_pred[i]][ (int)q_s->ss_conf[i]][0];
             }
             // access SS scores and write them to the ss_score array
-            for (j = 0; j <= (targetLength*VECSIZE_FLOAT); j++) // Loop through template positions j
+            for (j = 0; j <= (targetLength+1)*VECSIZE_FLOAT; j++) // Loop through template positions j
             {
-                ss_score[j] = ssw * score[t_index[j]];
+                ss_score[j + VECSIZE_FLOAT] = ssw * score[t_index[j]];
             }
         }
 #endif


### PR DESCRIPTION
This pull request fixes #193 issue.

simd_float * ss_score_vec is an alias for float * Viterbi::ss_score array. But use of ss_score_vec and ss_score is inconsistent in Viterbi::AlignWith... procedures: initialization of ss_score is performed from j=0 whereas ss_score_vec is indexed from j=1.
This leaves uninitialized the last positions of the array which results in occasionally wrong values of SS score in the last iteration of the inner loop (Vitrerbi + SS score = 1e+23) which in its turn causes either crash at the attempt to construct hit alignment or wrong hit outputs (huge score, zero E-value).

Unfortunately this error occurs only when several CPU cores are used and even then it's not 100% reproducible (depends on the heap memory layout which changes from run to run).
