### PR TITLE
Memory sanitizer issues

### DIFF
--- a/lib/ffindex/src/ffindex.c
+++ b/lib/ffindex/src/ffindex.c
@@ -292,6 +292,7 @@ ffindex_index_t* ffindex_index_parse(FILE *index_file, size_t num_max_entries)
     fferror_print(__FILE__, __LINE__, __func__, "malloc failed");
     return NULL;
   }
+  memset(index, 0, nbytes); // make clang memory sanitizer happy
   index->num_max_entries = num_max_entries;
 
   index->file = index_file;

--- a/src/hhhmm.cpp
+++ b/src/hhhmm.cpp
@@ -16,6 +16,8 @@ HMM::HMM(int maxseqdis, int maxres) : maxseqdis(maxseqdis), maxres(maxres) {
 	Neff_I = new float[maxres]; // Neff_I[i] = diversity of subalignment of seqs that have insert in col i
 	Neff_D = new float[maxres]; // Neff_D[i] = diversity of subalignment of seqs that have delete in col i
 	longname = new char[DESCLEN]; // Full name of first sequence of original alignment (NAME field)
+	// Make Clang memory sanitizer happy, avoid copying uninitialized values in HMM::operator=()
+	name[0] = file[0] = fam[0] = sfam[0] = fold[0] = cl[0] = '\0';
 	ss_dssp = new char[maxres]; // secondary structure determined by dssp 0:-  1:H  2:E  3:C  4:S  5:T  6:G  7:B
 	sa_dssp = new char[maxres]; // solvent accessibility state determined by dssp 0:-  1:A (absolutely buried) 2:B  3:C  4:D  5:E (exposed)
 	ss_pred = new char[maxres]; // predicted secondary structure          0:-  1:H  2:E  3:C

--- a/src/hhhmmsimd.cpp
+++ b/src/hhhmmsimd.cpp
@@ -129,8 +129,10 @@ void HMMSimd::MapHMMVector(std::vector<HMM *> hmms){
             for(int aa_i=0; aa_i < NAA;aa_i++){
                 p[i][aa_i*VECSIZE_FLOAT+seq_i]=curr->p[i][aa_i];
             }
-            pred_index[i * VECSIZE_FLOAT + seq_i] = (unsigned char) curr->ss_pred[i] * MAXCF + curr->ss_conf[i];
-            dssp_index[i * VECSIZE_FLOAT + seq_i] = (unsigned char) curr->ss_dssp[i];
+            if (i > 0){
+                pred_index[(i - 1) * VECSIZE_FLOAT + seq_i] = (unsigned char) curr->ss_pred[i] * MAXCF + curr->ss_conf[i];
+                dssp_index[(i - 1) * VECSIZE_FLOAT + seq_i] = (unsigned char) curr->ss_dssp[i];
+            }
         }
         for(int i = curr->L+1; i < this->L+1; i++){
             const unsigned int start_pos = i * VECSIZE_FLOAT * 7;
@@ -145,8 +147,14 @@ void HMMSimd::MapHMMVector(std::vector<HMM *> hmms){
             for(int aa_i=0; aa_i < NAA;aa_i++){
                 p[i][aa_i*VECSIZE_FLOAT+seq_i] = 0;
             }
-            pred_index[i * VECSIZE_FLOAT + seq_i] = 0;
-            dssp_index[i * VECSIZE_FLOAT + seq_i] = 0;
+            pred_index[(i - 1) * VECSIZE_FLOAT + seq_i] = 0;
+            dssp_index[(i - 1) * VECSIZE_FLOAT + seq_i] = 0;
+        }
+    }
+    for(unsigned int seq_i = hmms.size(); seq_i < VECSIZE_FLOAT; seq_i++){
+        for(int i = 1; i < this->L+1; i++){
+            pred_index[(i - 1) * VECSIZE_FLOAT + seq_i] = 0;
+            dssp_index[(i - 1) * VECSIZE_FLOAT + seq_i] = 0;
         }
     }
 }

--- a/src/hhviterbialgorithm.cpp
+++ b/src/hhviterbialgorithm.cpp
@@ -205,7 +205,7 @@ void Viterbi::AlignWithOutCellOff(HMMSimd* q, HMMSimd* t,ViterbiMatrix * viterbi
                 score = &S37[ (int)q_s->ss_pred[i]][ (int)q_s->ss_conf[i]][0];
             }
             // access SS scores and write them to the ss_score array
-            for (j = 0; j <= (targetLength+1)*VECSIZE_FLOAT; j++) // Loop through template positions j
+            for (j = 0; j < targetLength*VECSIZE_FLOAT; j++) // Loop through template positions j
             {
                 ss_score[j + VECSIZE_FLOAT] = ssw * score[t_index[j]];
             }


### PR DESCRIPTION
This patch fixes the issues in HHblits tool that have been detected with Clang memory sanitizer (MSAN) which detects the use of uninitialized values and similar misuses of memory access.

Firstly it has confirmed that the latest error in hhviterbialgorithm.cpp (#193) is indeed reported by MSAN. However it also showed that the fix was incomplete &ndash; upper limit of for() loop was wrong.

Secondly it revealed that pred_index and dssp_index arrays are indexed from 0 in hhviterbialgorithm.cpp but filled from 1 in HMMSimd::MapHMMVector.
Also these arrays were not properly filled when HMM in incomplete (i.e. hmms.size < VECSIZE_FLOAT).

After these fixes MSAN doesn't report any warnings during my tests (1 and 2 iterations of HHblits search in PfamA with a large HMM, the test that triggered SEGFAULTs in #193 issue).
Nevertheless please check the changes while considering merge of this pull request, I did my best in verifying this code but it's still highly non-trivial.

This pull request also has two changes for suppressing false warnings from MSAN: zeroing new index structure in ffindex.c and string initialization of character arrays in HMM::HMM() constructor.
