### PR TITLE
Enable optional executable suffix to indicate SIMD level

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,81 +182,81 @@ if (OPENMP_FOUND AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_link_libraries(HH_OBJECTS ${OpenMP_CXX_LIBRARIES})
 endif()
 
-add_executable(hhblits hhblits_app.cpp)
-target_link_libraries(hhblits HH_OBJECTS)
+add_executable(hhblits${EXE_SUFFIX} hhblits_app.cpp)
+target_link_libraries(hhblits${EXE_SUFFIX} HH_OBJECTS)
 
-add_executable(hhmake hhmake.cpp)
-target_link_libraries(hhmake HH_OBJECTS)
+add_executable(hhmake${EXE_SUFFIX} hhmake.cpp)
+target_link_libraries(hhmake${EXE_SUFFIX} HH_OBJECTS)
 
-add_executable(hhfilter hhfilter.cpp)
-target_link_libraries(hhfilter HH_OBJECTS)
+add_executable(hhfilter${EXE_SUFFIX} hhfilter.cpp)
+target_link_libraries(hhfilter${EXE_SUFFIX} HH_OBJECTS)
 
-add_executable(hhsearch hhblits_app.cpp)
-target_link_libraries(hhsearch HH_OBJECTS)
-set_property(TARGET hhsearch PROPERTY COMPILE_FLAGS "-DHHSEARCH=1")
+add_executable(hhsearch${EXE_SUFFIX} hhblits_app.cpp)
+target_link_libraries(hhsearch${EXE_SUFFIX} HH_OBJECTS)
+set_property(TARGET hhsearch${EXE_SUFFIX} PROPERTY COMPILE_FLAGS "-DHHSEARCH=1")
 
-add_executable(hhalign hhblits_app.cpp)
-target_link_libraries(hhalign HH_OBJECTS)
-set_property(TARGET hhalign PROPERTY COMPILE_FLAGS "-DHHALIGN=1")
+add_executable(hhalign${EXE_SUFFIX} hhblits_app.cpp)
+target_link_libraries(hhalign${EXE_SUFFIX} HH_OBJECTS)
+set_property(TARGET hhalign${EXE_SUFFIX} PROPERTY COMPILE_FLAGS "-DHHALIGN=1")
 
-add_executable(hhconsensus hhconsensus.cpp)
-target_link_libraries(hhconsensus HH_OBJECTS)
+add_executable(hhconsensus${EXE_SUFFIX} hhconsensus.cpp)
+target_link_libraries(hhconsensus${EXE_SUFFIX} HH_OBJECTS)
 
 add_library(A3M_COMPRESS a3m_compress.cpp)
 if (OPENMP_FOUND AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_link_libraries(A3M_COMPRESS ${OpenMP_CXX_LIBRARIES})
 endif()
 
-add_executable(a3m_extract a3m_extract.cpp)
-target_link_libraries(a3m_extract ffindex A3M_COMPRESS)
+add_executable(a3m_extract${EXE_SUFFIX} a3m_extract.cpp)
+target_link_libraries(a3m_extract${EXE_SUFFIX} ffindex A3M_COMPRESS)
 
-add_executable(a3m_reduce a3m_reduce.cpp)
-target_link_libraries(a3m_reduce ffindex A3M_COMPRESS)
+add_executable(a3m_reduce${EXE_SUFFIX} a3m_reduce.cpp)
+target_link_libraries(a3m_reduce${EXE_SUFFIX} ffindex A3M_COMPRESS)
 
-add_executable(a3m_database_reduce a3m_database_reduce.cpp )
-target_link_libraries(a3m_database_reduce ffindex A3M_COMPRESS)
+add_executable(a3m_database_reduce${EXE_SUFFIX} a3m_database_reduce.cpp )
+target_link_libraries(a3m_database_reduce${EXE_SUFFIX} ffindex A3M_COMPRESS)
 
-add_executable(a3m_database_extract a3m_database_extract.cpp)
-target_link_libraries(a3m_database_extract ffindex A3M_COMPRESS)
+add_executable(a3m_database_extract${EXE_SUFFIX} a3m_database_extract.cpp)
+target_link_libraries(a3m_database_extract${EXE_SUFFIX} ffindex A3M_COMPRESS)
 
-add_executable(a3m_database_filter a3m_database_filter.cpp)
-target_link_libraries(a3m_database_filter ffindex A3M_COMPRESS)
+add_executable(a3m_database_filter${EXE_SUFFIX} a3m_database_filter.cpp)
+target_link_libraries(a3m_database_filter${EXE_SUFFIX} ffindex A3M_COMPRESS)
 
-add_executable(cstranslate cs/cstranslate_app.cc)
-target_link_libraries(cstranslate HH_OBJECTS A3M_COMPRESS)
+add_executable(cstranslate${EXE_SUFFIX} cs/cstranslate_app.cc)
+target_link_libraries(cstranslate${EXE_SUFFIX} HH_OBJECTS A3M_COMPRESS)
 
 INSTALL(TARGETS
-        hhblits
-        hhmake
-        hhfilter
-        hhsearch
-        hhalign
-        hhconsensus
-        a3m_extract
-        a3m_reduce
-        a3m_database_reduce
-        a3m_database_extract
-        a3m_database_filter
-        cstranslate
+        hhblits${EXE_SUFFIX}
+        hhmake${EXE_SUFFIX}
+        hhfilter${EXE_SUFFIX}
+        hhsearch${EXE_SUFFIX}
+        hhalign${EXE_SUFFIX}
+        hhconsensus${EXE_SUFFIX}
+        a3m_extract${EXE_SUFFIX}
+        a3m_reduce${EXE_SUFFIX}
+        a3m_database_reduce${EXE_SUFFIX}
+        a3m_database_extract${EXE_SUFFIX}
+        a3m_database_filter${EXE_SUFFIX}
+        cstranslate${EXE_SUFFIX}
         DESTINATION bin
         )
 
 if (OPENMP_FOUND)
-    add_executable(hhblits_omp hhblits_omp.cpp)
-    target_link_libraries(hhblits_omp HH_OBJECTS)
+    add_executable(hhblits_omp${EXE_SUFFIX} hhblits_omp.cpp)
+    target_link_libraries(hhblits_omp${EXE_SUFFIX} HH_OBJECTS)
 
-    add_executable(hhsearch_omp hhblits_omp.cpp)
-    target_link_libraries(hhsearch_omp HH_OBJECTS)
-    set_property(TARGET hhsearch_omp PROPERTY COMPILE_FLAGS "-DHHSEARCH=1")
+    add_executable(hhsearch_omp${EXE_SUFFIX} hhblits_omp.cpp)
+    target_link_libraries(hhsearch_omp${EXE_SUFFIX} HH_OBJECTS)
+    set_property(TARGET hhsearch_omp${EXE_SUFFIX} PROPERTY COMPILE_FLAGS "-DHHSEARCH=1")
 
-    add_executable(hhalign_omp hhblits_omp.cpp)
-    target_link_libraries(hhalign_omp HH_OBJECTS)
-    set_property(TARGET hhalign_omp PROPERTY COMPILE_FLAGS "-DHHALIGN=1")
+    add_executable(hhalign_omp${EXE_SUFFIX} hhblits_omp.cpp)
+    target_link_libraries(hhalign_omp${EXE_SUFFIX} HH_OBJECTS)
+    set_property(TARGET hhalign_omp${EXE_SUFFIX} PROPERTY COMPILE_FLAGS "-DHHALIGN=1")
 
-    add_executable(hhblits_ca3m hhblits_ca3m.cpp)
-    target_link_libraries (hhblits_ca3m HH_OBJECTS)
+    add_executable(hhblits_ca3m${EXE_SUFFIX} hhblits_ca3m.cpp)
+    target_link_libraries (hhblits_ca3m${EXE_SUFFIX} HH_OBJECTS)
 
-    INSTALL(TARGETS hhblits_omp hhsearch_omp hhalign_omp hhblits_ca3m DESTINATION bin)
+    INSTALL(TARGETS hhblits_omp${EXE_SUFFIX} hhsearch_omp${EXE_SUFFIX} hhalign_omp${EXE_SUFFIX} hhblits_ca3m${EXE_SUFFIX} DESTINATION bin)
 endif ()
 
 if (${CHECK_MPI})
@@ -264,27 +264,27 @@ find_package(MPI QUIET)
 if (MPI_CXX_FOUND)
     include_directories(${MPI_CXX_INCLUDE_PATH})
 
-    add_executable(hhblits_mpi hhblits_mpi.cpp)
-    target_link_libraries(hhblits_mpi HH_OBJECTS mpq ${MPI_CXX_LIBRARIES})
-    set_target_properties(hhblits_mpi PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS}")
-    set_target_properties(hhblits_mpi PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
+    add_executable(hhblits_mpi${EXE_SUFFIX} hhblits_mpi.cpp)
+    target_link_libraries(hhblits_mpi${EXE_SUFFIX} HH_OBJECTS mpq ${MPI_CXX_LIBRARIES})
+    set_target_properties(hhblits_mpi${EXE_SUFFIX} PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS}")
+    set_target_properties(hhblits_mpi${EXE_SUFFIX} PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
 
-    add_executable(hhsearch_mpi hhblits_mpi.cpp)
-    target_link_libraries(hhsearch_mpi HH_OBJECTS mpq ${MPI_CXX_LIBRARIES})
-    set_target_properties(hhsearch_mpi PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS} -DHHSEARCH=1")
-    set_target_properties(hhsearch_mpi PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
+    add_executable(hhsearch_mpi${EXE_SUFFIX} hhblits_mpi.cpp)
+    target_link_libraries(hhsearch_mpi${EXE_SUFFIX} HH_OBJECTS mpq ${MPI_CXX_LIBRARIES})
+    set_target_properties(hhsearch_mpi${EXE_SUFFIX} PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS} -DHHSEARCH=1")
+    set_target_properties(hhsearch_mpi${EXE_SUFFIX} PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
 
-    add_executable(hhalign_mpi hhblits_mpi.cpp)
-    target_link_libraries(hhalign_mpi HH_OBJECTS mpq ${MPI_CXX_LIBRARIES})
-    set_target_properties(hhalign_mpi PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS} -DHHALIGN=1")
-    set_target_properties(hhalign_mpi PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
+    add_executable(hhalign_mpi${EXE_SUFFIX} hhblits_mpi.cpp)
+    target_link_libraries(hhalign_mpi${EXE_SUFFIX} HH_OBJECTS mpq ${MPI_CXX_LIBRARIES})
+    set_target_properties(hhalign_mpi${EXE_SUFFIX} PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS} -DHHALIGN=1")
+    set_target_properties(hhalign_mpi${EXE_SUFFIX} PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
 
-    add_executable(cstranslate_mpi cs/cstranslate_mpi_app.cc)
-    target_link_libraries(cstranslate_mpi HH_OBJECTS A3M_COMPRESS mpq ${MPI_CXX_LIBRARIES})
-    set_target_properties(cstranslate_mpi PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS}")
-    set_target_properties(cstranslate_mpi PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
+    add_executable(cstranslate_mpi${EXE_SUFFIX} cs/cstranslate_mpi_app.cc)
+    target_link_libraries(cstranslate_mpi${EXE_SUFFIX} HH_OBJECTS A3M_COMPRESS mpq ${MPI_CXX_LIBRARIES})
+    set_target_properties(cstranslate_mpi${EXE_SUFFIX} PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS}")
+    set_target_properties(cstranslate_mpi${EXE_SUFFIX} PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
 
-    install(TARGETS hhblits_mpi hhsearch_mpi hhalign_mpi cstranslate_mpi DESTINATION bin)
+    install(TARGETS hhblits_mpi${EXE_SUFFIX} hhsearch_mpi${EXE_SUFFIX} hhalign_mpi${EXE_SUFFIX} cstranslate_mpi${EXE_SUFFIX} DESTINATION bin)
 endif ()
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(HAVE_POWER9 0 CACHE BOOL "Have POWER9 CPU")
 set(HAVE_POWER8 0 CACHE BOOL "Have POWER8 CPU")
 set(HAVE_ARM8 0 CACHE BOOL "Have ARMv8 CPU")
 set(NATIVE_ARCH 1 CACHE BOOL "Assume native architecture for SIMD. Use one of the HAVE_* options or set CMAKE_CXX_FLAGS to the appropriate flags if you disable this.")
+set(EXE_SUFFIX "" CACHE STRING "Optional executable suffix, can be used to to indicate SIMD level corresponding to manually specified build flags.")
 
 # see https://wiki.debian.org/ArchitectureSpecificsMemo for char signedness
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -fsigned-char")


### PR DESCRIPTION
Hello!

Debian uses this patch as we compile hh-suite multiple times on x86-(64), one at each SIMD level.

As an alternative, hh-suite could implement runtime CPU dispatching 