### PR TITLE
Fix minor bug in hh-suite/scripts/hh_reader.py

### DIFF
--- a/scripts/hh_reader.py
+++ b/scripts/hh_reader.py
@@ -73,7 +73,7 @@ def parse_result(lines):
             if query_start is not None:
                 result = hhr_alignment(query_id, query_length, query_neff,
                                        template_id, template_length, template_info, template_neff,
-                                       query_seq, template_seq, (query_start, template_start),
+                                       "".join(query_seq), "".join(template_seq), (query_start, template_start),
                                        (query_end, template_end), probability, evalue, score,
                                        aligned_cols, identity, similarity, sum_probs)
                 results.append(result)


### PR DESCRIPTION
The 76 line in this python scrip should be changedt:
from
`query_seq, template_seq, (query_start, template_start),`
to
`"".join(query_seq), "".join(template_seq), (query_start, template_start),`

The query_seq and template_seq are both list, they need to be converted to a string to match same format as the line 172. And the output code from 192 to 198 will work successfully.