### PR TITLE
fix: accept over 127 parameters

### DIFF
--- a/src/hhdecl.h
+++ b/src/hhdecl.h
@@ -143,7 +143,7 @@ public:
   Parameters(const int argc, const char** argv);
 
   const char** argv;            //command line parameters
-  const char argc;              //dimension of argv
+  const int argc;              //dimension of argv
 
   LogLevel v;
 


### PR DESCRIPTION
Class `Parameters` was casting `argc` into to a `char`, limiting the number of accepted parameters.

Closes #243.