### PR TITLE
Add exception class to handle case where field in struct is not present

### DIFF
--- a/scripts/cif2fasta.py
+++ b/scripts/cif2fasta.py
@@ -271,7 +271,7 @@ class CIF2FASTA(object):
             
             return protein_description.strip(',')
         
-        except AttributeError:
+        except (AttributeError, ValueError):
             if DEBUG_MODE > 1:
                 print ('! {pdb} Could not extract pdbx_descriptor from struct table.'.format(
                     pdb = self.pdb_entry()))


### PR DESCRIPTION
When running `cif2fasta.py` with `7rs0.cif` from the RCSB DB as input gives the following exception:

```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/usr/local/hhsuite/scripts/cif2fasta.py", line 712, in wrapper_function
    fasta_entry = create_fasta_entry2(cif2fasta)
  File "/usr/local/hhsuite/scripts/cif2fasta.py", line 614, in create_fasta_entry2
    protein_description = cif2fasta.protein_description()
  File "/usr/local/hhsuite/scripts/cif2fasta.py", line 266, in protein_description
    protein_description = struct.getValue('pdbx_descriptor')
  File "/usr/local/lib/python3.8/dist-packages/pdbx/reader/PdbxContainers.py", line 464, in getValue
    return self._rowList[rowI][self._attributeNameList.index(attribute)]
ValueError: 'pdbx_descriptor' is not in list
"""
```

This is because the `7rs0.cif` from RCSB does not contain the `pdbx_descriptor` (which is not required):

`7rs0.cif`:

```
...
#
_struct.entry_id                     7RS0
_struct.title
'Crystal Structure of the ER-alpha Ligand-binding Domain (L372S, L536S) in complex with DMERI-18'
_struct.pdbx_model_details           ?
_struct.pdbx_formula_weight          ?
_struct.pdbx_formula_weight_method   ?
_struct.pdbx_model_type_details      ?
_struct.pdbx_CASP_flag               N
# 
...
```

Adding exception class to handle this case.