### PR TITLE
Use std::sort instead of QSortInt

### DIFF
--- a/src/hhalignment.cpp
+++ b/src/hhalignment.cpp
@@ -1677,7 +1677,7 @@ int Alignment::Filter2(char keep[], int coverage, int qid, float qsc,
     ksort = new int[N_in];  // never reuse alignment object for new alignment with more sequences
     for (k = 0; k < N_in; ++k)
       ksort[k] = k;
-    QSortInt(nres, ksort, kfirst + 1, N_in - 1, -1);  //Sort sequences after kfirst (query) in descending order
+    std::sort(ksort + kfirst + 1 , ksort+ N_in, [this](int a, int b){ return nres[a] > nres[b];});  //Sort sequences after kfirst (query) in descending order
   }
   for (kk = 0; kk < N_in; ++kk) {
     inkk[kk] = in[ksort[kk]];


### PR DESCRIPTION
I profiled the T1050 with the parameters run by AlphaFold. (Only -cpu is changed). I used Score-P as the profiling tool and got the following results.

<img width="1435" alt="pr" src="https://user-images.githubusercontent.com/40717344/150444606-57083866-ce1f-48a4-b6e2-7637da12daf7.png">

From this image, we can see that `QSortInt` in `mergeHitsToQuery` is taking a long time. With fast enough storage, my hhblits for this condition is about 2100sec, and `QSortInt` accounts for about 40%.

Instead of this `QsortInt`, use `std::sort`.

I ran hhblits installed by conda and using `std::sort` under the same conditions as before.
In order to avoid I/O effects, I analyze the difference in execution time between the logs that contain this change, instead of the overall execution time. (From https://github.com/soedinglab/hh-suite/blob/ac765987bd0daceb093a41a8e2850887dad5835f/src/hhblits.cpp#L1028-L1030 to https://github.com/soedinglab/hh-suite/blob/b100bb05fe6b920a7cbe58256eef72954d9088bf/src/hhhmm.cpp#L2337)

  | conda | use `std::sort`|
-- | -- | --|
iteration 1 | 1232(sec) | 477(sec)
iteration 2 | 631(sec) | 374(sec)
iteration 3 | 306(sec) | 232(sec)

This reduced the execution time. I also ran it using the parallelization policy, but the results were not significantly different from `std::sort`.

This change is due to the different stability of sort, so the execution results may not truly match.
