### PR TITLE
Fix token index of template length in hh_reader.py

### DIFF
--- a/scripts/hh_reader.py
+++ b/scripts/hh_reader.py
@@ -158,7 +158,7 @@ def parse_result(lines):
             template_end = max(template_end, token_4)
 
             try:
-                token_5 = tokens[4].replace("(", "").replace(")", "")
+                token_5 = tokens[5].replace("(", "").replace(")", "")
                 token_5 = int(token_5)
             except:
                 raise HHRFormatError(("Converting failure of template length ({}) "


### PR DESCRIPTION
In `hh_reader.py`, `template_length` was incorrectly parsed: the value of `template_length` was actually `template_end`, due to the incorrect token index. This PR fixed this typo.