### PR TITLE
compile issue on gcc13

### DIFF
--- a/src/a3m_compress.cpp
+++ b/src/a3m_compress.cpp
@@ -12,6 +12,9 @@
 #include <omp.h>
 #endif
 
+using std::uint16_t;
+using std::uint32_t;
+
 int compressed_a3m::compress_a3m(std::istream* input,
     ffindex_index_t* ffindex_sequence_database_index,
     char* ffindex_sequence_database_data, std::ostream* output) {

--- a/src/a3m_compress.h
+++ b/src/a3m_compress.h
@@ -16,10 +16,14 @@
 #include <algorithm>
 #include <cstring>
 #include <climits>
+#include <cstdint>
 
 extern "C" {
   #include <ffindex.h>     // fast index-based database reading
 }
+
+using std::uint16_t;
+using std::uint32_t;
 
 namespace compressed_a3m {
   int compress_a3m(std::istream* input, ffindex_index_t* ffindex_sequence_database_index, char* ffindex_sequence_database_data, std::ostream* output);


### PR DESCRIPTION
In gcc version >= 13.0 the typedefs of fundamental integral types should be accessed from the std namespace.

Compilation has been tested on gcc-8, gcc-13 and clang-13.